### PR TITLE
Add SwiftUI grocery delivery app skeleton

### DIFF
--- a/GroceryDeliveryApp/GroceryDeliveryApp.swift
+++ b/GroceryDeliveryApp/GroceryDeliveryApp.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+@main
+struct GroceryDeliveryApp: App {
+    @StateObject private var authViewModel = AuthenticationViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            if authViewModel.isAuthenticated {
+                MainTabView()
+                    .environmentObject(authViewModel)
+            } else {
+                AuthenticationView()
+                    .environmentObject(authViewModel)
+            }
+        }
+    }
+}

--- a/GroceryDeliveryApp/Models/CartItem.swift
+++ b/GroceryDeliveryApp/Models/CartItem.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct CartItem: Identifiable {
+    let id = UUID()
+    let product: Product
+    var quantity: Int
+}

--- a/GroceryDeliveryApp/Models/Category.swift
+++ b/GroceryDeliveryApp/Models/Category.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Category: Identifiable, Codable {
+    let id: Int
+    let name: String
+    let imageURL: URL?
+}

--- a/GroceryDeliveryApp/Models/Order.swift
+++ b/GroceryDeliveryApp/Models/Order.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct Order: Identifiable, Codable {
+    let id: Int
+    let date: Date
+    let items: [CartItem]
+    let total: Double
+}

--- a/GroceryDeliveryApp/Models/Product.swift
+++ b/GroceryDeliveryApp/Models/Product.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct Product: Identifiable, Codable {
+    let id: Int
+    let name: String
+    let description: String
+    let imageURL: URL?
+    let price: Double
+    let categoryID: Int
+}

--- a/GroceryDeliveryApp/Models/User.swift
+++ b/GroceryDeliveryApp/Models/User.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct User: Identifiable, Codable {
+    let id: Int
+    let name: String
+    let email: String
+    let token: String?
+}

--- a/GroceryDeliveryApp/README.md
+++ b/GroceryDeliveryApp/README.md
@@ -1,0 +1,20 @@
+# GroceryDeliveryApp
+
+A SwiftUI-based iOS app skeleton for a grocery delivery service using MVVM architecture.
+
+This project provides placeholder logic for connecting to a backend API and demonstrates how you might structure a modern SwiftUI application.
+
+## Features
+
+- User authentication (login/signup)
+- Browse categories and products
+- Cart with quantity adjustments
+- Delivery address input and scheduling
+- Secure checkout flow (placeholders for Stripe/Apple Pay)
+- Order history and reordering
+
+All network operations are stubbed out in `APIService` for integration with your backend.
+
+## Running
+
+Open the project in Xcode and run on iOS 15 or later.

--- a/GroceryDeliveryApp/Services/APIService.swift
+++ b/GroceryDeliveryApp/Services/APIService.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+class APIService {
+    static let shared = APIService()
+    private init() {}
+
+    let baseURL = URL(string: "https://api.example.com")!
+
+    func fetchCategories() async throws -> [Category] {
+        // Placeholder: /categories
+        return []
+    }
+
+    func fetchProducts(in categoryID: Int?) async throws -> [Product] {
+        // Placeholder: /products or /categories/:id/products
+        return []
+    }
+
+    func login(email: String, password: String) async throws -> User {
+        // Placeholder: /login
+        return User(id: 1, name: "Demo", email: email, token: nil)
+    }
+
+    func createAccount(name: String, email: String, password: String) async throws -> User {
+        // Placeholder: /signup
+        return User(id: 1, name: name, email: email, token: nil)
+    }
+
+    func checkout(cartItems: [CartItem], address: String, scheduledDate: Date) async throws -> Order {
+        // Placeholder: /checkout
+        return Order(id: Int.random(in: 1000...9999), date: Date(), items: cartItems, total: cartItems.reduce(0) { $0 + $1.product.price * Double($1.quantity) })
+    }
+
+    func fetchOrderHistory() async throws -> [Order] {
+        // Placeholder: /orders
+        return []
+    }
+}

--- a/GroceryDeliveryApp/ViewModels/AuthenticationViewModel.swift
+++ b/GroceryDeliveryApp/ViewModels/AuthenticationViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+class AuthenticationViewModel: ObservableObject {
+    @Published var user: User?
+    @Published var isAuthenticated = false
+
+    func login(email: String, password: String) async {
+        do {
+            let user = try await APIService.shared.login(email: email, password: password)
+            DispatchQueue.main.async {
+                self.user = user
+                self.isAuthenticated = true
+            }
+        } catch {
+            print("Login error: \(error)")
+        }
+    }
+
+    func signup(name: String, email: String, password: String) async {
+        do {
+            let user = try await APIService.shared.createAccount(name: name, email: email, password: password)
+            DispatchQueue.main.async {
+                self.user = user
+                self.isAuthenticated = true
+            }
+        } catch {
+            print("Signup error: \(error)")
+        }
+    }
+}

--- a/GroceryDeliveryApp/ViewModels/CartViewModel.swift
+++ b/GroceryDeliveryApp/ViewModels/CartViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+class CartViewModel: ObservableObject {
+    @Published var items: [CartItem] = []
+
+    var total: Double {
+        items.reduce(0) { $0 + $1.product.price * Double($1.quantity) }
+    }
+
+    func add(product: Product) {
+        if let index = items.firstIndex(where: { $0.product.id == product.id }) {
+            items[index].quantity += 1
+        } else {
+            items.append(CartItem(product: product, quantity: 1))
+        }
+    }
+
+    func remove(product: Product) {
+        items.removeAll { $0.product.id == product.id }
+    }
+
+    func updateQuantity(for product: Product, quantity: Int) {
+        guard let index = items.firstIndex(where: { $0.product.id == product.id }) else { return }
+        items[index].quantity = quantity
+    }
+
+    func clear() {
+        items.removeAll()
+    }
+}

--- a/GroceryDeliveryApp/ViewModels/CheckoutViewModel.swift
+++ b/GroceryDeliveryApp/ViewModels/CheckoutViewModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+class CheckoutViewModel: ObservableObject {
+    @Published var address: String = ""
+    @Published var scheduledDate: Date = Date()
+    // TODO: integrate CoreLocation for auto-detecting address or map pin selection
+    @Published var isProcessing = false
+    @Published var lastOrder: Order?
+
+    func checkout(cart: CartViewModel) async {
+        guard !cart.items.isEmpty else { return }
+        isProcessing = true
+        do {
+            let order = try await APIService.shared.checkout(cartItems: cart.items, address: address, scheduledDate: scheduledDate)
+            DispatchQueue.main.async {
+                self.lastOrder = order
+                self.isProcessing = false
+                cart.clear()
+            }
+        } catch {
+            DispatchQueue.main.async { self.isProcessing = false }
+            print("Checkout error: \(error)")
+        }
+    }
+}

--- a/GroceryDeliveryApp/ViewModels/OrderHistoryViewModel.swift
+++ b/GroceryDeliveryApp/ViewModels/OrderHistoryViewModel.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+class OrderHistoryViewModel: ObservableObject {
+    @Published var orders: [Order] = []
+
+    func loadHistory() async {
+        do {
+            let orders = try await APIService.shared.fetchOrderHistory()
+            DispatchQueue.main.async {
+                self.orders = orders
+            }
+        } catch {
+            print("Order history error: \(error)")
+        }
+    }
+}

--- a/GroceryDeliveryApp/ViewModels/ProductListViewModel.swift
+++ b/GroceryDeliveryApp/ViewModels/ProductListViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+class ProductListViewModel: ObservableObject {
+    @Published var categories: [Category] = []
+    @Published var products: [Product] = []
+
+    func loadCategories() async {
+        do {
+            let categories = try await APIService.shared.fetchCategories()
+            DispatchQueue.main.async {
+                self.categories = categories
+            }
+        } catch {
+            print("Category fetch error: \(error)")
+        }
+    }
+
+    func loadProducts(for category: Category?) async {
+        do {
+            let products = try await APIService.shared.fetchProducts(in: category?.id)
+            DispatchQueue.main.async {
+                self.products = products
+            }
+        } catch {
+            print("Product fetch error: \(error)")
+        }
+    }
+}

--- a/GroceryDeliveryApp/Views/AuthenticationView.swift
+++ b/GroceryDeliveryApp/Views/AuthenticationView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct AuthenticationView: View {
+    @EnvironmentObject var viewModel: AuthenticationViewModel
+    @State private var isLogin = true
+    @State private var name = ""
+    @State private var email = ""
+    @State private var password = ""
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                if !isLogin {
+                    TextField("Name", text: $name)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                }
+                TextField("Email", text: $email)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .keyboardType(.emailAddress)
+                SecureField("Password", text: $password)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button(isLogin ? "Login" : "Sign Up") {
+                    Task {
+                        if isLogin {
+                            await viewModel.login(email: email, password: password)
+                        } else {
+                            await viewModel.signup(name: name, email: email, password: password)
+                        }
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                Button(isLogin ? "Create an account" : "Have an account? Login") {
+                    isLogin.toggle()
+                }
+                Spacer()
+            }
+            .padding()
+            .navigationTitle(isLogin ? "Login" : "Sign Up")
+        }
+    }
+}
+
+struct AuthenticationView_Previews: PreviewProvider {
+    static var previews: some View {
+        AuthenticationView()
+            .environmentObject(AuthenticationViewModel())
+    }
+}

--- a/GroceryDeliveryApp/Views/CartView.swift
+++ b/GroceryDeliveryApp/Views/CartView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct CartView: View {
+    @EnvironmentObject var cartViewModel: CartViewModel
+    @StateObject private var checkoutViewModel = CheckoutViewModel()
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                List {
+                    ForEach(cartViewModel.items) { item in
+                        HStack {
+                            Text(item.product.name)
+                            Spacer()
+                            Stepper(value: Binding(
+                                get: { item.quantity },
+                                set: { cartViewModel.updateQuantity(for: item.product, quantity: $0) }
+                            ), in: 1...20) {
+                                Text("Qty: \(item.quantity)")
+                            }
+                        }
+                    }
+                    if cartViewModel.items.isEmpty {
+                        Text("Your cart is empty")
+                    }
+                }
+                VStack(spacing: 10) {
+                    TextField("Delivery Address", text: $checkoutViewModel.address)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    DatePicker("Delivery Time", selection: $checkoutViewModel.scheduledDate, displayedComponents: [.date, .hourAndMinute])
+                    Text("Total: $\(cartViewModel.total, specifier: "%.2f")")
+                        .font(.headline)
+                    Button("Checkout") {
+                        Task { await checkoutViewModel.checkout(cart: cartViewModel) }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    if checkoutViewModel.isProcessing {
+                        ProgressView()
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Cart")
+        }
+    }
+}
+
+struct CartView_Previews: PreviewProvider {
+    static var previews: some View {
+        CartView()
+            .environmentObject(CartViewModel())
+    }
+}

--- a/GroceryDeliveryApp/Views/MainTabView.swift
+++ b/GroceryDeliveryApp/Views/MainTabView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct MainTabView: View {
+    @StateObject private var cartViewModel = CartViewModel()
+    @StateObject private var productListViewModel = ProductListViewModel()
+    @StateObject private var orderHistoryViewModel = OrderHistoryViewModel()
+
+    var body: some View {
+        TabView {
+            ProductListView()
+                .environmentObject(productListViewModel)
+                .environmentObject(cartViewModel)
+                .tabItem { Label("Shop", systemImage: "cart") }
+            CartView()
+                .environmentObject(cartViewModel)
+                .tabItem { Label("Cart", systemImage: "cart.fill") }
+            OrderHistoryView()
+                .environmentObject(orderHistoryViewModel)
+                .tabItem { Label("Orders", systemImage: "clock") }
+        }
+    }
+}
+
+struct MainTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainTabView()
+    }
+}

--- a/GroceryDeliveryApp/Views/OrderHistoryView.swift
+++ b/GroceryDeliveryApp/Views/OrderHistoryView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct OrderHistoryView: View {
+    @EnvironmentObject var viewModel: OrderHistoryViewModel
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(viewModel.orders) { order in
+                    VStack(alignment: .leading) {
+                        Text(order.date, style: .date)
+                            .font(.headline)
+                        Text("Items: \(order.items.count) | Total: $\(order.total, specifier: "%.2f")")
+                        Button("Reorder") {
+                            // Placeholder for reorder action
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+            }
+            .task { await viewModel.loadHistory() }
+            .navigationTitle("Order History")
+        }
+    }
+}
+
+struct OrderHistoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        OrderHistoryView()
+            .environmentObject(OrderHistoryViewModel())
+    }
+}

--- a/GroceryDeliveryApp/Views/ProductListView.swift
+++ b/GroceryDeliveryApp/Views/ProductListView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct ProductListView: View {
+    @EnvironmentObject var viewModel: ProductListViewModel
+    @EnvironmentObject var cartViewModel: CartViewModel
+    @State private var selectedCategory: Category?
+
+    var body: some View {
+        NavigationView {
+            List {
+                if !viewModel.categories.isEmpty {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack {
+                            ForEach(viewModel.categories) { category in
+                                Button(action: {
+                                    selectedCategory = category
+                                    Task { await viewModel.loadProducts(for: category) }
+                                }) {
+                                    VStack {
+                                        if let url = category.imageURL {
+                                            AsyncImage(url: url) { image in
+                                                image.resizable()
+                                            } placeholder: { Color.gray }
+                                            .frame(width: 60, height: 60)
+                                            .clipShape(Circle())
+                                        }
+                                        Text(category.name)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                ForEach(viewModel.products) { product in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(product.name)
+                                .font(.headline)
+                            Text(product.description)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            Text("$\(product.price, specifier: "%.2f")")
+                                .font(.subheadline)
+                        }
+                        Spacer()
+                        Button(action: { cartViewModel.add(product: product) }) {
+                            Image(systemName: "plus.circle.fill")
+                        }
+                    }
+                }
+            }
+            .task {
+                await viewModel.loadCategories()
+                await viewModel.loadProducts(for: selectedCategory)
+            }
+            .navigationTitle("Products")
+        }
+    }
+}
+
+struct ProductListView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProductListView()
+            .environmentObject(ProductListViewModel())
+            .environmentObject(CartViewModel())
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# Scripts
+# Scripts Repository
+
+This repository contains example scripts and sample apps. The `GroceryDeliveryApp` directory includes a SwiftUI-based iOS application skeleton for a grocery delivery service.
+
+Refer to `GroceryDeliveryApp/README.md` for details.


### PR DESCRIPTION
## Summary
- introduce `GroceryDeliveryApp` example iOS project with MVVM design
- add models, view models, and services for placeholder API calls
- implement SwiftUI views for authentication, product list, cart, and orders
- document project in dedicated README
- update repo README with new project location

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684a9fc175ec832a8613b0a0045e60b6